### PR TITLE
Bug fix for issue #4 (Filter per day)

### DIFF
--- a/CodeCamper.Web/Scripts/app/vm.favorites.js
+++ b/CodeCamper.Web/Scripts/app/vm.favorites.js
@@ -102,7 +102,7 @@
             },
 
             setFilter = function () {
-                var day = new Date(selectedDate());
+                var day = new Date(moment(selectedDate(), "MM-DD-YYYY").format());
                 sessionFilter
                     .minDate(day)
                     .maxDate(utils.endOfDay(day))


### PR DESCRIPTION
Previous code received the selectedDate from URL in the 'MM-DD-YYYY' format and tried to parse it into a Date directly. This work very well on a server with a local setting of 'MM-DD-YYYY' but not on other settings.
Using moment.js, it allows to be local setting agnostic.
